### PR TITLE
Correção para o valor de `c` no I.C. bilateral para variância desconhecida 

### DIFF
--- a/slides/aula_16.tex
+++ b/slides/aula_16.tex
@@ -31,7 +31,7 @@
 
 \begin{frame}{Teste t: motivação}
  Suponha que estamos interessados em testar hipóteses sobre a média ($\mu$) de uma distribuição Normal quando a variância ($\sigma^2$) é desconhecida.
- Sabemos que é possível encontrar uma quantidade pivotal $(\Sm-\mu)/\hat{\sigma}^\prime$ tal que é possível construir um intervalo de confiança para $\mu$ da forma $\Sm - c\hat{\sigma}^\prime/\sqrt{n}, \Sm + c\hat{\sigma}^\prime/\sqrt{n}$, onde $c = T^{-1}(\gamma; n-1)$ é a f.d.a. inversa de uma distribuição t de Student com $n-1$ graus de liberdade.
+ Sabemos que é possível encontrar uma quantidade pivotal $(\Sm-\mu)/\hat{\sigma}^\prime$ tal que é possível construir um intervalo de confiança para $\mu$ da forma $( \Sm - c\hat{\sigma}^\prime/\sqrt{n}, \Sm + c\hat{\sigma}^\prime/\sqrt{n} )$, onde $c = T^{-1}((1 + \gamma)/2; n-1)$ é a f.d.a. inversa de uma distribuição t de Student com $n-1$ graus de liberdade.
  
  \begin{pergunta}[Como falar sobre $\mu$ quando ambas $\mu$ e $\sigma^2$ são desconhecidas?]
  \label{qst:unknown_mean_and_variance}


### PR DESCRIPTION
Professor, acho que nesse slide o valor de `c` deveria ser `(1 + gama)/2`, não?
Também adicionei parênteses no IC.