### PR TITLE
Typo na definição do c de um teste de hipóteses

### DIFF
--- a/slides/aula_15.tex
+++ b/slides/aula_15.tex
@@ -54,7 +54,7 @@ Ver Teorema 9.1.1 de DeGroot.
    H_1&: \mu \neq \mu_0.
   \end{align*}
   Seja $\alpha_0 = 1-\gamma$. 
-  Lembre-se de que o teste de tamanho $\alpha_0$, $\delta_{\mu_0}$ é rejeitar $H_0$ se $|\Sm-\mu_0| \geq c$, $c := \Phi^{-1}\left(1-\alpha_0/2\right)\sigma\sqrt{n}$.
+  Lembre-se de que o teste de tamanho $\alpha_0$, $\delta_{\mu_0}$ é rejeitar $H_0$ se $|\Sm-\mu_0| \geq c$, $c := \Phi^{-1}\left(1-\alpha_0/2\right)\sigma/\sqrt{n}$.
   Esta última desigualdade pode ser manipulada algebricamente para obter o intervalo de confiança exato
   $$ (A(\bX), B(\bX)) = \left( \Sm - c, \Sm + c\right), $$
   de modo que $\pr(A(\bX) < \mu_0 < B(\bX) | \mu = \mu_0) = \gamma$.


### PR DESCRIPTION
O c deveria dividir pela raiz de n, e não multiplicar.